### PR TITLE
Add constraints to synapse property inputs.

### DIFF
--- a/fz_td_recipe/data/schema.yaml
+++ b/fz_td_recipe/data/schema.yaml
@@ -174,8 +174,14 @@ properties:
             u_hill_coefficient:
               type: number
           patternProperties:
-            "^((decay|depression|facilitation)_time|conductance|u_syn)_(sd|mu)":
+            "^(decay_time|u_syn)_mu":
               type: number
+            "^(decay_time|u_syn)_sd":
+              type: number
+              exclusiveMinimum: 0
+            "^((depression|facilitation)_time|conductance)_(sd|mu)":
+              type: number
+              exclusiveMinimum: 0
       rules:
         oneOf:
           - type: array

--- a/tests/test_synapse_property.py
+++ b/tests/test_synapse_property.py
@@ -1,18 +1,89 @@
 """Test synapse property mapping"""
 
+import json
 from io import StringIO
 
-from fz_td_recipe import XMLRecipe
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from fz_td_recipe import Recipe, XMLRecipe
 
 
 def test_synapse_properties():
-    r = XMLRecipe(StringIO(RECIPE))
+    r = XMLRecipe(StringIO(RECIPE_XML))
     assert set(r.synapse_properties.rules.required) == set(
         ["fromRegion", "fromHemisphere", "toRegion", "toHemisphere"]
     )
 
 
-RECIPE = """\
+def test_valid_synapse_properties(circuit_config, tmp_path, parameter):
+    data = json.loads(RECIPE_JSON)
+
+    recipe_file = tmp_path / "recipe.json"
+    with recipe_file.open("w") as fd:
+        json.dump(data, fd)
+    Recipe(recipe_file, circuit_config, (None, None))
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        "decay_time_sd",
+        "u_syn_sd",
+        "depression_time_mu",
+        "depression_time_sd",
+        "facilitation_time_mu",
+        "facilitation_time_sd",
+        "conductance_mu",
+        "conductance_sd",
+    ],
+)
+def test_invalid_synapse_properties(circuit_config, tmp_path, parameter):
+    data = json.loads(RECIPE_JSON)
+    data["synapse_properties"]["classes"][0][parameter] = 0.0
+
+    recipe_file = tmp_path / "recipe.json"
+    with recipe_file.open("w") as fd:
+        json.dump(data, fd)
+    with pytest.raises(ValidationError):
+        Recipe(recipe_file, circuit_config, (None, None))
+
+
+RECIPE_JSON = """\
+{
+  "bouton_distances": {},
+  "gap_junction_properties": {},
+  "seed": 0,
+  "synapse_properties": {
+    "rules": [
+      {
+        "src_mtype": "*",
+        "class": "I1"
+      }
+    ],
+    "classes": [
+      {
+        "class": "I1",
+        "n_rrp_vesicles_mu": 1,
+        "conductance_mu": 0.0,
+        "conductance_sd": 0.1,
+        "decay_time_mu": 8.3,
+        "decay_time_sd": 2.2,
+        "u_syn_mu": 0.25,
+        "u_syn_sd": 0.13,
+        "depression_time_mu": 706.0,
+        "depression_time_sd": 405.0,
+        "facilitation_time_mu": 21.0,
+        "facilitation_time_sd": 9.0
+      }
+    ]
+  },
+  "version": 1
+}
+"""
+
+
+RECIPE_XML = """\
 <?xml version="1.0"?>
 <blueColumn>
   <SynapsesProperties>

--- a/tests/test_synapse_property.py
+++ b/tests/test_synapse_property.py
@@ -16,7 +16,7 @@ def test_synapse_properties():
     )
 
 
-def test_valid_synapse_properties(circuit_config, tmp_path, parameter):
+def test_valid_synapse_properties(circuit_config, tmp_path):
     data = json.loads(RECIPE_JSON)
 
     recipe_file = tmp_path / "recipe.json"
@@ -45,7 +45,7 @@ def test_invalid_synapse_properties(circuit_config, tmp_path, parameter):
     recipe_file = tmp_path / "recipe.json"
     with recipe_file.open("w") as fd:
         json.dump(data, fd)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=parameter):
         Recipe(recipe_file, circuit_config, (None, None))
 
 
@@ -65,7 +65,7 @@ RECIPE_JSON = """\
       {
         "class": "I1",
         "n_rrp_vesicles_mu": 1,
-        "conductance_mu": 0.0,
+        "conductance_mu": 1.0,
         "conductance_sd": 0.1,
         "decay_time_mu": 8.3,
         "decay_time_sd": 2.2,


### PR DESCRIPTION
Having these values be zero or smaller will lead to non-sensical
probability distribution inputs, either for the standard deviation of
all distributions, or for the scale of the gamma distribution.

Fixes #9
